### PR TITLE
Add DSL to better reflect the SSHKit style (e.g. run_locally)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## Unreleased
+### Feature
+- add DSL for interactive command invocation (`run_interactively`)
+
+## 0.1.0 (2015-01-02) (Initial release)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Note that you will probably only want to execute on a single host. In Capistrano
 namespace :rails do
   desc "Run Rails console"
   task :console do
-    SSHKit.config.backend = SSHKit::Interactive::Backend
-    on primary(:app) do |host|
+    run_interactively primary(:app) do
       execute(:rails, :console)
     end
   end

--- a/lib/sshkit/interactive.rb
+++ b/lib/sshkit/interactive.rb
@@ -3,6 +3,7 @@ require 'sshkit'
 require_relative 'interactive/version'
 require_relative 'interactive/command'
 require_relative 'interactive/backend'
+require_relative 'interactive/dsl'
 
 module SSHKit
   module Interactive

--- a/lib/sshkit/interactive/backend.rb
+++ b/lib/sshkit/interactive/backend.rb
@@ -8,6 +8,7 @@ module SSHKit
 
       def within(directory, &_block)
         (@pwd ||= []).push(directory.to_s)
+
         yield
       ensure
         @pwd.pop

--- a/lib/sshkit/interactive/dsl.rb
+++ b/lib/sshkit/interactive/dsl.rb
@@ -1,0 +1,11 @@
+module SSHKit
+  module Interactive
+    module DSL
+      def run_interactively(host, &block)
+        SSHKit::Interactive::Backend.new(host, &block).run
+      end
+    end
+  end
+end
+
+include SSHKit::Interactive::DSL

--- a/lib/sshkit/interactive/dsl.rb
+++ b/lib/sshkit/interactive/dsl.rb
@@ -2,7 +2,17 @@ module SSHKit
   module Interactive
     module DSL
       def run_interactively(host, &block)
+        Thread.current[:run_interactively] = true
+
         SSHKit::Interactive::Backend.new(host, &block).run
+      ensure
+        Thread.current[:run_interactively] = false
+      end
+
+      def on(*args)
+        raise 'Switching host in interactive mode is not possible' if Thread.current[:run_interactively]
+
+        super
       end
     end
   end

--- a/spec/backend_spec.rb
+++ b/spec/backend_spec.rb
@@ -3,10 +3,6 @@ describe SSHKit::Interactive::Backend do
     let(:host) { SSHKit::Host.new('example.com') }
     let(:backend) { SSHKit::Interactive::Backend.new(host) }
 
-    def expect_system_call(command)
-      expect_any_instance_of(SSHKit::Interactive::Command).to receive(:system).with(command)
-    end
-
     it "does a system call with the SSH command" do
       expect_system_call('ssh -A -t example.com "/usr/bin/env ls"')
       backend.execute('ls')

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -1,0 +1,15 @@
+describe SSHKit::Interactive::DSL do
+  describe '#run_interactively' do
+    include SSHKit::Interactive::DSL
+
+    let(:host) { SSHKit::Host.new('example.com') }
+
+    it "initialize a new command" do
+      expect_system_call('ssh -A -t example.com "/usr/bin/env ls"')
+
+      run_interactively host do
+        execute(:ls)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,5 +96,9 @@ RSpec.configure do |config|
   config.before(:each) do
     # block all system calls
     allow_any_instance_of(SSHKit::Interactive::Command).to receive(:system)
+
+    def expect_system_call(command)
+      expect_any_instance_of(SSHKit::Interactive::Command).to receive(:system).with(command)
+    end
   end
 end


### PR DESCRIPTION
SSHKit uses run_locally to specify that everything in the block should be run locally instead of remotely.

This will integrate `sshkit-interactive` with the same pattern: `run_interactively` 
