### PR TITLE
prevent calling of unsupported backend operations

### DIFF
--- a/lib/sshkit/interactive/backend.rb
+++ b/lib/sshkit/interactive/backend.rb
@@ -18,6 +18,15 @@ module SSHKit
         output << remote_command
         Command.new(host, remote_command).execute
       end
+
+      def _unsupported_operation(*args)
+        raise ::SSHKit::Backend::MethodUnavailableError, 'SSHKit::Interactive does not support this operation.'
+      end
+
+      alias :upload! :_unsupported_operation
+      alias :download! :_unsupported_operation
+      alias :test :_unsupported_operation
+      alias :capture :_unsupported_operation
     end
   end
 end

--- a/spec/backend_spec.rb
+++ b/spec/backend_spec.rb
@@ -31,5 +31,23 @@ describe SSHKit::Interactive::Backend do
     it "respects the specified env"
 
     it "respects the specified user"
+
+    describe 'prevents calling unsupported operations' do
+      it '#upload!' do
+        expect { backend.upload!(:a, :b) }.to raise_error(::SSHKit::Backend::MethodUnavailableError)
+      end
+
+      it '#download!' do
+        expect { backend.download!(:a, :b) }.to raise_error(::SSHKit::Backend::MethodUnavailableError)
+      end
+
+      it '#test' do
+        expect { backend.test(:true) }.to raise_error(::SSHKit::Backend::MethodUnavailableError)
+      end
+
+      it '#capture' do
+        expect { backend.capture(:ls) }.to raise_error(::SSHKit::Backend::MethodUnavailableError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Last PR for today :smirk: (one of the next PRs will be a big one)

`upload`, `download`, `test` and `capture` shouldn't be called with the interactive backend so an exception should be raised.
