### PR TITLE
Fix incorrect variable expansion

### DIFF
--- a/lib/sshkit/interactive/command.rb
+++ b/lib/sshkit/interactive/command.rb
@@ -42,7 +42,7 @@ module SSHKit
           :ssh,
           *ssh_cmd_args,
           host.hostname,
-          %Q{"\\$SHELL -l -c \\"#{remote_command.to_command}\\""}
+          %Q{'$SHELL -l -c "#{remote_command.to_command}"'}
         ].reject(&:empty?).join(' ')
       end
 


### PR DESCRIPTION
Using single quotes around the shell command prevents environment variables
from being evaluated from the local machine rather than the remote.

For example, if a user, 'local' were sshing to a machine as user 'remote',
executing `$HOME/bin/foo` would incorrectly expand to `/home/local/bin/foo`,
which likely would not exist on the remote machine, rather than the correct
path of `/home/remote/bin/foo`