### PR TITLE
change quotes to allow nested quotes in commands

### DIFF
--- a/lib/sshkit/interactive/command.rb
+++ b/lib/sshkit/interactive/command.rb
@@ -42,7 +42,7 @@ module SSHKit
           :ssh,
           *ssh_cmd_args,
           host.hostname,
-          %Q{'$SHELL -l -c "#{remote_command.to_command}"'}
+          command
         ].reject(&:empty?).join(' ')
       end
 
@@ -83,6 +83,12 @@ module SSHKit
 
       def proxy_command
         proxy.command_line_template
+      end
+
+      def command
+        cmd = remote_command.to_command.gsub("'", "\\\"") # replace single quotes with double quotes
+
+        %Q{'$SHELL -l -c \"#{cmd}\"'}
       end
     end
   end

--- a/spec/backend_spec.rb
+++ b/spec/backend_spec.rb
@@ -4,20 +4,22 @@ describe SSHKit::Interactive::Backend do
     let(:backend) { SSHKit::Interactive::Backend.new(host) }
 
     it 'does a system call with the SSH command' do
-      expect_system_call('ssh -t -A example.com "\\$SHELL -l -c \\"/usr/bin/env ls\\""')
+      expect_system_call('ssh -t -A example.com \'$SHELL -l -c "/usr/bin/env ls"\'')
       backend.execute('ls')
     end
 
     it 'respects the specified directory' do
       backend.within('/var/log') do
-        expect_system_call('ssh -t -A example.com "\\$SHELL -l -c \\"cd /var/log && /usr/bin/env ls\\""')
+        expect_system_call('ssh -t -A example.com \'$SHELL -l -c "cd /var/log && /usr/bin/env ls"\'')
+
         backend.execute('ls')
       end
     end
 
     it 'respects the specified user' do
       backend.as('deployer') do
-        expect_system_call('ssh -t -A example.com "\\$SHELL -l -c \\"sudo -u deployer -- sh -c \'/usr/bin/env ls\'\\""')
+        expect_system_call('ssh -t -A example.com \'$SHELL -l -c "sudo -u deployer -- sh -c \\"/usr/bin/env ls\\""\'')
+
         backend.execute('ls')
       end
     end
@@ -32,7 +34,8 @@ describe SSHKit::Interactive::Backend do
 
     it 'respects the specified env' do
       backend.with(foo: :bar) do
-        expect_system_call('ssh -t -A example.com "\\$SHELL -l -c \\"( export FOO="bar" ; /usr/bin/env ls )\\""')
+        expect_system_call('ssh -t -A example.com \'$SHELL -l -c "( export FOO="bar" ; /usr/bin/env ls )"\'')
+
         backend.execute('ls')
       end
     end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -85,20 +85,20 @@ describe SSHKit::Interactive::Command do
       cmd = SSHKit::Interactive::Command.new(host, command)
 
       expect(cmd).to receive(:ssh_cmd_args).and_return(%w(-A -B -C))
-      expect(cmd.to_s).to eq('ssh -A -B -C example.com "\\$SHELL -l -c \\"/usr/bin/env ls\\""')
+      expect(cmd.to_s).to eq('ssh -A -B -C example.com \'$SHELL -l -c "/usr/bin/env ls"\'')
     end
 
     it 'excludes options if they\'re blank' do
       cmd = SSHKit::Interactive::Command.new(host, command)
 
       expect(cmd).to receive(:ssh_cmd_args).and_return([])
-      expect(cmd.to_s).to eq('ssh example.com "\\$SHELL -l -c \\"/usr/bin/env ls\\""')
+      expect(cmd.to_s).to eq('ssh example.com \'$SHELL -l -c "/usr/bin/env ls"\'')
     end
 
     it 'accepts a remote command' do
       cmd = SSHKit::Interactive::Command.new(host, command)
 
-      expect(cmd.to_s).to eq('ssh -t -A example.com "\\$SHELL -l -c \\"/usr/bin/env ls\\""')
+      expect(cmd.to_s).to eq('ssh -t -A example.com \'$SHELL -l -c "/usr/bin/env ls"\'')
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -5,7 +5,7 @@ describe SSHKit::Interactive::DSL do
     let(:host) { SSHKit::Host.new('example.com') }
 
     it 'will execute interactively' do
-      expect_system_call('ssh -t -A example.com "\\$SHELL -l -c \\"/usr/bin/env ls\\""')
+      expect_system_call('ssh -t -A example.com \'$SHELL -l -c "/usr/bin/env ls"\'')
 
       run_interactively host do
         execute(:ls)


### PR DESCRIPTION
Sadly PR #16 introduced a new bug if using nested single quotes. capistrano/sshkit generates commands with single quotes if e.g. using `as` for sudo.

Example:
```ruby
run_interactively primary(:app) do
  as user: 'my_user' do
    execute(:whoami)
  end
end
```

Also I fixed the tests that didn't test for the new command that are generated.