### PR TITLE
Fix Travis builds by removing bundler as development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 language: ruby
 
 rvm:
-  - ruby-2.2.6
-  - ruby-2.3.3
-  - ruby-2.4.0
+  - ruby-2.2.7
+  - ruby-2.3.4
+  - ruby-2.4.1
   - jruby-1.7
-  - jruby-9.1.7.0
+  - jruby-9.1.12.0
 
 gemfile:
   - spec/gemfiles/net-ssh2_8.gemfile
@@ -30,8 +30,5 @@ matrix:
       gemfile: spec/gemfiles/net-ssh4_0.gemfile
     - rvm: jruby-1.7
       gemfile: spec/gemfiles/net-ssh4_1.gemfile
-
-before_install:
-  - gem install bundler -v '~> 1.14.0'
 
 script: bundle exec rake spec

--- a/sshkit-interactive.gemspec
+++ b/sshkit-interactive.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sshkit', '~> 1.12'
 
-  spec.add_development_dependency 'bundler', '~> 1.14.0'
-  spec.add_development_dependency 'rake',    '~> 12.0.0'
-  spec.add_development_dependency 'rspec',   '~> 3.5.0'
+  spec.add_development_dependency 'rake',  '~> 12.0.0'
+  spec.add_development_dependency 'rspec', '~> 3.5.0'
 end


### PR DESCRIPTION
Updated the rubies to current versions and removed bundler as a development dependency.

The Travis build will still fail due to the missing updates for the tests after changing the command generation - see #18 