### PR TITLE
Update README to indicate sshkit-interactive should not be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An [SSHKit](https://github.com/capistrano/sshkit) [backend](https://github.com/c
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'sshkit-interactive'
+gem 'sshkit-interactive', require: false
 ```
 
 And then execute:


### PR DESCRIPTION
Super excited to stumble across this gem via https://github.com/ydkn/capistrano-rails-console. This functionality needs to be in Capistrano by default!

However, if you leave `sshkit-interactive` to be required by Bundler, the top-level `include SSHKit::Interactive::DSL` in `lib/sshkit/interactive/dsl.rb` pollutes your app. This can cause some really obscure errors including the one we encountered, when our tests ran:

```
ActionView::Template::Error:
  super: no superclass method `on' for #<Haml::Escapable:0x0000000005bfcc28>
```

The full fix will be to not do a top-level `include`, but this is the first step!